### PR TITLE
Unify card style across desktop sections

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Heart, Lightbulb } from 'lucide-react';
+import { Heart } from 'lucide-react';
 
 const About: React.FC = () => {
   return (

--- a/src/components/ForWho.tsx
+++ b/src/components/ForWho.tsx
@@ -48,18 +48,18 @@ const ForWho: React.FC = () => {
           
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 md:gap-8">
             {audiences.map((item, index) => (
-              <div 
-                key={index}
-                className="bg-white p-4 md:p-6 rounded-3xl shadow-lg hover:shadow-xl transition-all duration-300 border border-gray-100 group"
-              >
-                <div className="text-center">
-                  <div className="w-12 h-12 mx-auto mb-4 bg-gray-50 rounded-2xl flex items-center justify-center group-hover:scale-110 transition-transform duration-300">
-                    {React.cloneElement(item.icon, { className: "w-6 h-6", style: { color: '#7d91b2' } })}
+              <div key={index} className="card">
+                <div className="text-center flex flex-col h-full">
+                  <div className="card-icon">
+                    {React.cloneElement(item.icon, { className: 'w-6 h-6', style: { color: '#7d91b2' } })}
                   </div>
-                  <h3 className="text-xs md:text-sm font-bold text-gray-900 mb-2 leading-tight" style={{ fontFamily: 'Good Times Grotesk, sans-serif' }}>
+                  <h3
+                    className="text-xs md:text-sm font-bold text-gray-900 mb-2 leading-tight"
+                    style={{ fontFamily: 'Good Times Grotesk, sans-serif' }}
+                  >
                     {item.title}
                   </h3>
-                  <p className="text-xs text-gray-600 leading-relaxed">
+                  <p className="text-xs text-gray-600 leading-relaxed flex-grow">
                     {item.description}
                   </p>
                 </div>

--- a/src/components/HowItWorks.tsx
+++ b/src/components/HowItWorks.tsx
@@ -58,18 +58,16 @@ const HowItWorks: React.FC = () => {
           
           <div className="grid grid-cols-2 md:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-8">
             {features.map((feature, index) => (
-              <div 
-                key={index}
-                className="bg-white p-4 md:p-6 rounded-3xl shadow-lg hover:shadow-xl transition-all duration-300 border border-gray-100 group"
-              >
-                <div className="text-center">
-                  <div className="w-12 h-12 mx-auto mb-4 bg-gray-50 rounded-2xl flex items-center justify-center group-hover:scale-110 transition-transform duration-300">
-                    {feature.icon}
-                  </div>
-                  <h3 className="text-xs md:text-sm font-bold text-gray-900 mb-2 leading-tight" style={{ fontFamily: 'Good Times Grotesk, sans-serif' }}>
+              <div key={index} className="card">
+                <div className="text-center flex flex-col h-full">
+                  <div className="card-icon">{feature.icon}</div>
+                  <h3
+                    className="text-xs md:text-sm font-bold text-gray-900 mb-2 leading-tight"
+                    style={{ fontFamily: 'Good Times Grotesk, sans-serif' }}
+                  >
                     {feature.title}
                   </h3>
-                  <p className="text-xs text-gray-600 leading-relaxed">
+                  <p className="text-xs text-gray-600 leading-relaxed flex-grow">
                     {feature.description}
                   </p>
                 </div>

--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -123,9 +123,9 @@ const Testimonials: React.FC = () => {
             <div className="overflow-hidden">
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                 {visibleSlides.map((testimonial, index) => (
-                  <div 
+                  <div
                     key={`${currentSlide}-${index}`}
-                    className="bg-gradient-to-br from-gray-50 to-white border border-gray-200 rounded-2xl p-8 hover:shadow-xl transition-all duration-300 transform hover:scale-105"
+                    className="card bg-gradient-to-br from-gray-50 to-white border border-gray-200 p-8 transform hover:scale-105"
                   >
                     <div className="flex items-center mb-6">
                       <div className={`w-16 h-16 ${testimonial.photo} rounded-full mr-4 flex items-center justify-center`}>

--- a/src/components/WhatYouGet.tsx
+++ b/src/components/WhatYouGet.tsx
@@ -48,18 +48,16 @@ const WhatYouGet: React.FC = () => {
           
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 md:gap-8">
             {benefits.map((benefit, index) => (
-              <div 
-                key={index}
-                className="bg-white p-4 md:p-6 rounded-3xl shadow-lg hover:shadow-xl transition-all duration-300 border border-gray-100 group"
-              >
-                <div className="text-center">
-                  <div className="w-12 h-12 mx-auto mb-4 bg-gray-50 rounded-2xl flex items-center justify-center group-hover:scale-110 transition-transform duration-300">
-                    {benefit.icon}
-                  </div>
-                  <h3 className="text-xs md:text-sm font-bold text-gray-900 mb-2 leading-tight" style={{ fontFamily: 'Good Times Grotesk, sans-serif' }}>
+              <div key={index} className="card">
+                <div className="text-center flex flex-col h-full">
+                  <div className="card-icon">{benefit.icon}</div>
+                  <h3
+                    className="text-xs md:text-sm font-bold text-gray-900 mb-2 leading-tight"
+                    style={{ fontFamily: 'Good Times Grotesk, sans-serif' }}
+                  >
                     {benefit.title}
                   </h3>
-                  <p className="text-xs text-gray-600 leading-relaxed">
+                  <p className="text-xs text-gray-600 leading-relaxed flex-grow">
                     {benefit.description}
                   </p>
                 </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,12 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Unified card styles for desktop */
+.card {
+  @apply bg-white p-4 md:p-6 rounded-3xl shadow-lg hover:shadow-xl transition-all duration-300 border border-gray-100 group md:min-h-60 flex flex-col;
+}
+
+.card-icon {
+  @apply w-12 h-12 mx-auto mb-4 bg-gray-50 rounded-2xl flex items-center justify-center group-hover:scale-110 transition-transform duration-300;
+}


### PR DESCRIPTION
## Summary
- add reusable `.card` and `.card-icon` styles
- use unified card styles in ForWho, WhatYouGet, HowItWorks and Testimonials components
- clean up unused import

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687cc75d0fd083308752510af70731fc